### PR TITLE
feat: provider-contracts, core, and providers-testkit with acceptance test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,102 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+  agent-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify agent artifacts
+        run: pnpm agent:verify
+
+  docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build and verify docs
+        run: pnpm docs:verify
+        env:
+          DOCUSAURUS_BASE_URL: /multiverse/

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,58 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs
+        run: pnpm docs:build
+        env:
+          DOCUSAURUS_BASE_URL: /multiverse/
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/docs/build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.js";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@multiverse/core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@multiverse/provider-contracts": "workspace:*"
+  }
+}

--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -1,0 +1,261 @@
+import type {
+  EndpointDeclaration,
+  EndpointAppEnvMapping,
+  IsolationStrategy,
+  ResourceDeclaration
+} from "@multiverse/provider-contracts";
+import { isValidFixedHostPortBasePort } from "@multiverse/provider-contracts";
+
+export interface DeclarationValidationError {
+  path: string;
+  code:
+    | "required"
+    | "invalid_value"
+    | "invalid_env_var_name"
+    | "reserved_name"
+    | "duplicate_appenv"
+    | "invalid_appenv_mapping_kind";
+}
+
+export interface ValidatedResourceDeclaration {
+  name: string;
+  provider: string;
+  isolationStrategy: IsolationStrategy;
+  scopedValidate: boolean;
+  scopedReset: boolean;
+  scopedCleanup: boolean;
+  appEnv?: string;
+}
+
+export interface ValidatedEndpointDeclaration {
+  name: string;
+  role: string;
+  provider: string;
+  appEnv?: string | EndpointAppEnvMapping;
+  host?: string;
+  basePort?: number;
+}
+
+export interface EndpointDeclarationValidationError {
+  path: "name" | "role" | "provider" | "appEnv" | "host" | "basePort";
+  code:
+    | "required"
+    | "invalid_value"
+    | "invalid_env_var_name"
+    | "reserved_name"
+    | "invalid_appenv_mapping_kind";
+}
+
+export type EndpointDeclarationValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: EndpointDeclarationValidationError[] };
+
+const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const RESERVED_PREFIX = "MULTIVERSE_";
+
+function isValidEnvVarName(name: string): boolean {
+  return ENV_VAR_NAME_PATTERN.test(name);
+}
+
+function isReservedEnvVarName(name: string): boolean {
+  return name.startsWith(RESERVED_PREFIX);
+}
+
+function requiredError(path: string): DeclarationValidationError {
+  return { path, code: "required" };
+}
+
+function requiredEndpointError(
+  path: EndpointDeclarationValidationError["path"]
+): EndpointDeclarationValidationError {
+  return { path, code: "required" };
+}
+
+function appEnvErrors(value: string, pathPrefix: string): DeclarationValidationError[] {
+  const errors: DeclarationValidationError[] = [];
+  if (!isValidEnvVarName(value)) {
+    errors.push({ path: `${pathPrefix}.appEnv`, code: "invalid_env_var_name" });
+  } else if (isReservedEnvVarName(value)) {
+    errors.push({ path: `${pathPrefix}.appEnv`, code: "reserved_name" });
+  }
+  return errors;
+}
+
+function endpointAppEnvErrors(
+  value: string | EndpointAppEnvMapping
+): EndpointDeclarationValidationError[] {
+  if (typeof value === "string") {
+    const errors: EndpointDeclarationValidationError[] = [];
+    if (!isValidEnvVarName(value)) {
+      errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+    } else if (isReservedEnvVarName(value)) {
+      errors.push({ path: "appEnv", code: "reserved_name" });
+    }
+    return errors;
+  }
+
+  const errors: EndpointDeclarationValidationError[] = [];
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+    return errors;
+  }
+
+  for (const [envName, kind] of entries) {
+    if (!isValidEnvVarName(envName)) {
+      errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+      continue;
+    }
+    if (isReservedEnvVarName(envName)) {
+      errors.push({ path: "appEnv", code: "reserved_name" });
+      continue;
+    }
+    if (kind !== "url" && kind !== "port") {
+      errors.push({ path: "appEnv", code: "invalid_appenv_mapping_kind" });
+    }
+  }
+
+  return errors;
+}
+
+function invalidEndpointValueError(
+  path: EndpointDeclarationValidationError["path"]
+): EndpointDeclarationValidationError {
+  return { path, code: "invalid_value" };
+}
+
+function fixedHostPortConfigErrors(
+  input: EndpointDeclaration
+): EndpointDeclarationValidationError[] {
+  const errors: EndpointDeclarationValidationError[] = [];
+
+  if (input.host === undefined) {
+    errors.push(requiredEndpointError("host"));
+  } else if (typeof input.host !== "string" || input.host.trim().length === 0) {
+    errors.push(invalidEndpointValueError("host"));
+  }
+
+  if (input.basePort === undefined) {
+    errors.push(requiredEndpointError("basePort"));
+  } else if (!isValidFixedHostPortBasePort(input.basePort)) {
+    errors.push(invalidEndpointValueError("basePort"));
+  }
+
+  return errors;
+}
+
+export function validateResourceDeclaration(input: {
+  resource: ResourceDeclaration;
+  index: number;
+}):
+  | { ok: true; value: ValidatedResourceDeclaration }
+  | { ok: false; errors: DeclarationValidationError[] } {
+  const { resource, index } = input;
+  const errors: DeclarationValidationError[] = [];
+
+  if (!resource.name) {
+    errors.push(requiredError(`resources[${index}].name`));
+  }
+  if (!resource.provider) {
+    errors.push(requiredError(`resources[${index}].provider`));
+  }
+  if (!resource.isolationStrategy) {
+    errors.push(requiredError(`resources[${index}].isolationStrategy`));
+  }
+  if (typeof resource.scopedReset !== "boolean") {
+    errors.push(requiredError(`resources[${index}].scopedReset`));
+  }
+  if (typeof resource.scopedCleanup !== "boolean") {
+    errors.push(requiredError(`resources[${index}].scopedCleanup`));
+  }
+  if (resource.appEnv !== undefined) {
+    errors.push(...appEnvErrors(resource.appEnv, `resources[${index}]`));
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name: resource.name!,
+      provider: resource.provider!,
+      isolationStrategy: resource.isolationStrategy!,
+      scopedValidate: resource.scopedValidate === true,
+      scopedReset: resource.scopedReset!,
+      scopedCleanup: resource.scopedCleanup!,
+      ...(resource.appEnv !== undefined ? { appEnv: resource.appEnv } : {})
+    }
+  };
+}
+
+export function validateEndpointDeclaration(
+  input: EndpointDeclaration
+): EndpointDeclarationValidationResult<ValidatedEndpointDeclaration> {
+  const errors: EndpointDeclarationValidationError[] = [];
+
+  if (!input.name) errors.push(requiredEndpointError("name"));
+  if (!input.role) errors.push(requiredEndpointError("role"));
+  if (!input.provider) errors.push(requiredEndpointError("provider"));
+
+  if (input.provider === "fixed-host-port") {
+    errors.push(...fixedHostPortConfigErrors(input));
+  }
+
+  if (input.appEnv !== undefined) {
+    errors.push(...endpointAppEnvErrors(input.appEnv));
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return {
+    ok: true,
+    value: {
+      name: input.name!,
+      role: input.role!,
+      provider: input.provider!,
+      ...(input.provider === "fixed-host-port" && input.host !== undefined
+        ? { host: input.host }
+        : {}),
+      ...(input.provider === "fixed-host-port" && input.basePort !== undefined
+        ? { basePort: input.basePort }
+        : {}),
+      ...(input.appEnv !== undefined ? { appEnv: input.appEnv } : {})
+    }
+  };
+}
+
+export function withValidatedEndpointDeclaration<TResult>(
+  input: EndpointDeclaration,
+  onValidated: (endpoint: ValidatedEndpointDeclaration) => TResult
+): EndpointDeclarationValidationResult<TResult> {
+  const validation = validateEndpointDeclaration(input);
+  if (!validation.ok) {
+    return validation;
+  }
+  return { ok: true, value: onValidated(validation.value) };
+}
+
+export function validateIndexedEndpointDeclaration(input: {
+  endpoint: EndpointDeclaration;
+  index: number;
+}):
+  | { ok: true; value: ValidatedEndpointDeclaration }
+  | { ok: false; errors: DeclarationValidationError[] } {
+  const validation = validateEndpointDeclaration(input.endpoint);
+
+  if (!validation.ok) {
+    return {
+      ok: false,
+      errors: validation.errors.map((error) => ({
+        path: `endpoints[${input.index}].${error.path}`,
+        code: error.code as DeclarationValidationError["code"]
+      }))
+    };
+  }
+
+  return { ok: true, value: validation.value };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,60 @@
+import type {
+  CleanupOneResourceResult,
+  DeriveAndValidateOneResult,
+  DeriveOneResult,
+  ProviderRegistry,
+  ResetOneResourceResult,
+  RepositoryConfiguration,
+  WorktreeInstanceInput
+} from "@multiverse/provider-contracts";
+import {
+  resolveAndDeriveAll,
+  resolveAndDeriveAllWithValidation,
+  resolveAndResetAll,
+  resolveAndCleanupAll
+} from "./orchestration.js";
+
+export {
+  validateWorktreeIdentity,
+  withValidatedWorktreeIdentity
+} from "./worktree-identity.js";
+export {
+  validateEndpointDeclaration,
+  withValidatedEndpointDeclaration
+} from "./declarations.js";
+export {
+  validateRepositoryConfiguration,
+  withValidatedRepositoryConfiguration
+} from "./repository-configuration.js";
+
+export function deriveOne(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): DeriveOneResult {
+  return resolveAndDeriveAll(input);
+}
+
+export function deriveAndValidateOne(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): DeriveAndValidateOneResult {
+  return resolveAndDeriveAllWithValidation(input);
+}
+
+export function resetOneResource(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): Promise<ResetOneResourceResult> {
+  return resolveAndResetAll(input);
+}
+
+export function cleanupOneResource(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): Promise<CleanupOneResourceResult> {
+  return resolveAndCleanupAll(input);
+}

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -1,0 +1,352 @@
+import type {
+  CleanupOneResourceResult,
+  DeriveAndValidateOneResult,
+  DerivedEndpointMapping,
+  DerivedResourcePlan,
+  ProviderRegistry,
+  RepositoryConfiguration,
+  ResourceCleanup,
+  ResourceReset,
+  ResourceValidation,
+  ResetOneResourceResult,
+  WorktreeInstanceInput
+} from "@multiverse/provider-contracts";
+import { withValidatedRepositoryConfiguration } from "./repository-configuration.js";
+import {
+  invalidConfiguration,
+  isFailureOutcome,
+  isRefusal,
+  unsupportedCapability,
+  unsafeScope,
+  type FailureResult
+} from "./refusals.js";
+import { validateWorktreeIdentity } from "./worktree-identity.js";
+
+interface ResolvedWorktree {
+  id: string;
+  label?: string;
+  branch?: string;
+}
+
+function requireResolvedWorktree(
+  worktree: WorktreeInstanceInput
+): ResolvedWorktree | FailureResult {
+  const validation = validateWorktreeIdentity({
+    ...(worktree.id !== undefined ? { worktreeId: worktree.id } : {})
+  });
+  if (!validation.ok) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+  return {
+    id: validation.value.value,
+    ...(worktree.label !== undefined ? { label: worktree.label } : {}),
+    ...(worktree.branch !== undefined ? { branch: worktree.branch } : {})
+  };
+}
+
+function validateCapabilityIntent(input: {
+  resource: {
+    provider: string;
+    scopedValidate: boolean;
+    scopedReset: boolean;
+    scopedCleanup: boolean;
+  };
+  provider: {
+    capabilities?: {
+      validate?: true;
+      reset?: true;
+      cleanup?: true;
+    };
+  };
+}): void | FailureResult {
+  const { resource, provider } = input;
+
+  if (resource.scopedValidate && !provider.capabilities?.validate) {
+    return unsupportedCapability(
+      `Resource provider "${resource.provider}" does not support validate.`
+    );
+  }
+  if (resource.scopedReset && !provider.capabilities?.reset) {
+    return unsupportedCapability(
+      `Resource provider "${resource.provider}" does not support reset.`
+    );
+  }
+  if (resource.scopedCleanup && !provider.capabilities?.cleanup) {
+    return unsupportedCapability(
+      `Resource provider "${resource.provider}" does not support cleanup.`
+    );
+  }
+}
+
+export function resolveAndDeriveAll(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): { ok: true; resourcePlans: DerivedResourcePlan[]; endpointMappings: DerivedEndpointMapping[] } | FailureResult {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) return resolvedWorktree;
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const endpointMappings: DerivedEndpointMapping[] = [];
+
+  for (const resourceDecl of repo.resources) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    const capabilityCheck = validateCapabilityIntent({
+      resource: resourceDecl,
+      provider: resourceProvider
+    });
+    if (isFailureOutcome(capabilityCheck)) return capabilityCheck;
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) return { ok: false, refusal: plan };
+    resourcePlans.push(plan);
+  }
+
+  for (const endpointDecl of repo.endpoints) {
+    const endpointProvider = input.providers.endpoints[endpointDecl.provider];
+    if (!endpointProvider) {
+      return invalidConfiguration(
+        `No endpoint provider is registered for "${endpointDecl.provider}".`
+      );
+    }
+
+    const mapping = endpointProvider.deriveEndpoint({
+      endpoint: endpointDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(mapping)) return { ok: false, refusal: mapping };
+    endpointMappings.push(mapping);
+  }
+
+  return { ok: true, resourcePlans, endpointMappings };
+}
+
+export function resolveAndDeriveAllWithValidation(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): DeriveAndValidateOneResult {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) return resolvedWorktree;
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const endpointMappings: DerivedEndpointMapping[] = [];
+  const resourceValidations: ResourceValidation[] = [];
+
+  for (const resourceDecl of repo.resources) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    const capabilityCheck = validateCapabilityIntent({
+      resource: resourceDecl,
+      provider: resourceProvider
+    });
+    if (isFailureOutcome(capabilityCheck)) return capabilityCheck;
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) return { ok: false, refusal: plan };
+    resourcePlans.push(plan);
+
+    if (resourceDecl.scopedValidate) {
+      if (!resourceProvider.capabilities?.validate || !resourceProvider.validateResource) {
+        return {
+          ok: false,
+          refusal: {
+            category: "unsupported_capability",
+            reason: `Resource provider "${resourceDecl.provider}" does not support validate.`
+          }
+        };
+      }
+      const validation = resourceProvider.validateResource({
+        resource: resourceDecl,
+        derived: plan,
+        worktree: resolvedWorktree
+      });
+      if (isRefusal(validation)) return { ok: false, refusal: validation };
+      resourceValidations.push(validation);
+    }
+  }
+
+  for (const endpointDecl of repo.endpoints) {
+    const endpointProvider = input.providers.endpoints[endpointDecl.provider];
+    if (!endpointProvider) {
+      return invalidConfiguration(
+        `No endpoint provider is registered for "${endpointDecl.provider}".`
+      );
+    }
+    const mapping = endpointProvider.deriveEndpoint({
+      endpoint: endpointDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(mapping)) return { ok: false, refusal: mapping };
+    endpointMappings.push(mapping);
+  }
+
+  return { ok: true, resourcePlans, endpointMappings, resourceValidations };
+}
+
+export async function resolveAndResetAll(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): Promise<ResetOneResourceResult> {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) return resolvedWorktree;
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const resetTargets = repo.resources.filter((r) => r.scopedReset);
+
+  if (resetTargets.length === 0) {
+    return invalidConfiguration(
+      "No resources declare scoped reset intent. Reset requires at least one resource with scopedReset: true."
+    );
+  }
+
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const resourceResets: ResourceReset[] = [];
+
+  for (const resourceDecl of resetTargets) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    if (!resourceProvider.capabilities?.reset || !resourceProvider.resetResource) {
+      return {
+        ok: false,
+        refusal: {
+          category: "unsupported_capability",
+          reason: `Resource provider "${resourceDecl.provider}" does not support reset.`
+        }
+      };
+    }
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) return { ok: false, refusal: plan };
+
+    const reset = await resourceProvider.resetResource({
+      resource: resourceDecl,
+      derived: plan,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(reset)) return { ok: false, refusal: reset };
+
+    resourcePlans.push(plan);
+    resourceResets.push(reset);
+  }
+
+  return { ok: true, resourcePlans, resourceResets };
+}
+
+export async function resolveAndCleanupAll(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): Promise<CleanupOneResourceResult> {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) return resolvedWorktree;
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const cleanupTargets = repo.resources.filter((r) => r.scopedCleanup);
+
+  if (cleanupTargets.length === 0) {
+    return invalidConfiguration(
+      "No resources declare scoped cleanup intent. Cleanup requires at least one resource with scopedCleanup: true."
+    );
+  }
+
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const resourceCleanups: ResourceCleanup[] = [];
+
+  for (const resourceDecl of cleanupTargets) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    if (!resourceProvider.capabilities?.cleanup || !resourceProvider.cleanupResource) {
+      return {
+        ok: false,
+        refusal: {
+          category: "unsupported_capability",
+          reason: `Resource provider "${resourceDecl.provider}" does not support cleanup.`
+        }
+      };
+    }
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) return { ok: false, refusal: plan };
+
+    const cleanup = await resourceProvider.cleanupResource({
+      resource: resourceDecl,
+      derived: plan,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(cleanup)) return { ok: false, refusal: cleanup };
+
+    resourcePlans.push(plan);
+    resourceCleanups.push(cleanup);
+  }
+
+  return { ok: true, resourcePlans, resourceCleanups };
+}

--- a/packages/core/src/refusals.ts
+++ b/packages/core/src/refusals.ts
@@ -1,0 +1,45 @@
+import type { Refusal } from "@multiverse/provider-contracts";
+
+export interface FailureResult {
+  ok: false;
+  refusal: Refusal;
+}
+
+export function invalidConfiguration(reason: string): FailureResult {
+  return {
+    ok: false,
+    refusal: { category: "invalid_configuration", reason }
+  };
+}
+
+export function unsafeScope(reason: string): FailureResult {
+  return {
+    ok: false,
+    refusal: { category: "unsafe_scope", reason }
+  };
+}
+
+export function unsupportedCapability(reason: string): FailureResult {
+  return {
+    ok: false,
+    refusal: { category: "unsupported_capability", reason }
+  };
+}
+
+export function isFailureOutcome(value: unknown): value is FailureResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    (value as { ok: unknown }).ok === false
+  );
+}
+
+export function isRefusal(value: unknown): value is Refusal {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "category" in value &&
+    "reason" in value
+  );
+}

--- a/packages/core/src/repository-configuration.ts
+++ b/packages/core/src/repository-configuration.ts
@@ -1,0 +1,94 @@
+import type { RepositoryConfiguration } from "@multiverse/provider-contracts";
+import {
+  validateIndexedEndpointDeclaration,
+  validateResourceDeclaration,
+  type DeclarationValidationError,
+  type ValidatedEndpointDeclaration,
+  type ValidatedResourceDeclaration
+} from "./declarations.js";
+
+export interface ValidatedRepositoryConfiguration {
+  resources: ValidatedResourceDeclaration[];
+  endpoints: ValidatedEndpointDeclaration[];
+}
+
+export type RepositoryConfigurationValidationError = DeclarationValidationError;
+
+export type RepositoryConfigurationValidationResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; errors: RepositoryConfigurationValidationError[] };
+
+export function validateRepositoryConfiguration(
+  input: RepositoryConfiguration
+): RepositoryConfigurationValidationResult<ValidatedRepositoryConfiguration> {
+  const errors: RepositoryConfigurationValidationError[] = [];
+  const resources: ValidatedResourceDeclaration[] = [];
+  const endpoints: ValidatedEndpointDeclaration[] = [];
+
+  for (const [index, resource] of input.resources.entries()) {
+    const validation = validateResourceDeclaration({ resource, index });
+    if (!validation.ok) {
+      errors.push(...validation.errors);
+      continue;
+    }
+    resources.push(validation.value);
+  }
+
+  for (const [index, endpoint] of input.endpoints.entries()) {
+    const validation = validateIndexedEndpointDeclaration({ endpoint, index });
+    if (!validation.ok) {
+      errors.push(...validation.errors);
+      continue;
+    }
+    endpoints.push(validation.value);
+  }
+
+  // Cross-declaration duplicate appEnv check (only when individual validations pass).
+  if (errors.length === 0) {
+    const seen = new Map<string, string>();
+
+    for (const [index, resource] of resources.entries()) {
+      if (resource.appEnv === undefined) continue;
+      const existing = seen.get(resource.appEnv);
+      if (existing !== undefined) {
+        errors.push({ path: `resources[${index}].appEnv`, code: "duplicate_appenv" });
+      } else {
+        seen.set(resource.appEnv, `resources[${index}].appEnv`);
+      }
+    }
+
+    for (const [index, endpoint] of endpoints.entries()) {
+      if (endpoint.appEnv === undefined) continue;
+      const names =
+        typeof endpoint.appEnv === "string"
+          ? [endpoint.appEnv]
+          : Object.keys(endpoint.appEnv);
+
+      for (const envName of names) {
+        const existing = seen.get(envName);
+        if (existing !== undefined) {
+          errors.push({ path: `endpoints[${index}].appEnv`, code: "duplicate_appenv" });
+        } else {
+          seen.set(envName, `endpoints[${index}].appEnv`);
+        }
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, value: { resources, endpoints } };
+}
+
+export function withValidatedRepositoryConfiguration<TResult>(
+  input: RepositoryConfiguration,
+  onValidated: (repository: ValidatedRepositoryConfiguration) => TResult
+): RepositoryConfigurationValidationResult<TResult> {
+  const validation = validateRepositoryConfiguration(input);
+  if (!validation.ok) {
+    return validation;
+  }
+  return { ok: true, value: onValidated(validation.value) };
+}

--- a/packages/core/src/worktree-identity.ts
+++ b/packages/core/src/worktree-identity.ts
@@ -1,0 +1,68 @@
+export interface RawWorktreeIdentityInput {
+  worktreeId?: string;
+}
+
+export interface WorktreeIdentity {
+  kind: "worktree_identity";
+  value: string;
+}
+
+export interface ValidationError {
+  path: "worktreeId";
+  code: "required" | "invalid_value";
+}
+
+export type ValidationResult<T> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      ok: false;
+      errors: ValidationError[];
+    };
+
+function createWorktreeIdentity(value: string): WorktreeIdentity {
+  return {
+    kind: "worktree_identity",
+    value
+  };
+}
+
+export function validateWorktreeIdentity(
+  input: RawWorktreeIdentityInput
+): ValidationResult<WorktreeIdentity> {
+  if (input.worktreeId === undefined) {
+    return {
+      ok: false,
+      errors: [{ path: "worktreeId", code: "required" }]
+    };
+  }
+
+  if (input.worktreeId.trim().length === 0) {
+    return {
+      ok: false,
+      errors: [{ path: "worktreeId", code: "invalid_value" }]
+    };
+  }
+
+  return {
+    ok: true,
+    value: createWorktreeIdentity(input.worktreeId)
+  };
+}
+
+export function withValidatedWorktreeIdentity<TResult>(
+  input: RawWorktreeIdentityInput,
+  onValidated: (worktreeIdentity: WorktreeIdentity) => TResult
+): ValidationResult<TResult> {
+  const validation = validateWorktreeIdentity(input);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  return {
+    ok: true,
+    value: onValidated(validation.value)
+  };
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "paths": {
+      "@multiverse/provider-contracts": ["../provider-contracts/index.ts"]
+    }
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/packages/provider-contracts/index.ts
+++ b/packages/provider-contracts/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.js";

--- a/packages/provider-contracts/package.json
+++ b/packages/provider-contracts/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@multiverse/provider-contracts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  }
+}

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -1,0 +1,239 @@
+export type IsolationStrategy =
+  | "name-scoped"
+  | "path-scoped"
+  | "process-scoped"
+  | "process-port-scoped";
+
+export type RefusalCategory =
+  | "invalid_configuration"
+  | "unsupported_capability"
+  | "unsafe_scope"
+  | "provider_failure";
+
+export interface ProviderCapabilities {
+  validate?: true;
+  reset?: true;
+  cleanup?: true;
+}
+
+export interface Refusal {
+  category: RefusalCategory;
+  reason: string;
+}
+
+export interface WorktreeInstanceInput {
+  id?: string;
+  label?: string;
+  branch?: string;
+}
+
+export interface ResourceDeclaration {
+  name?: string;
+  provider?: string;
+  isolationStrategy?: IsolationStrategy;
+  scopedValidate?: boolean;
+  scopedReset?: boolean;
+  scopedCleanup?: boolean;
+  appEnv?: string;
+}
+
+export type EndpointAppEnvValueKind = "url" | "port";
+export type EndpointAppEnvMapping = Record<string, EndpointAppEnvValueKind>;
+
+export interface EndpointDeclaration {
+  name?: string;
+  role?: string;
+  provider?: string;
+  appEnv?: string | EndpointAppEnvMapping;
+  host?: string;
+  basePort?: number;
+}
+
+export const FIXED_HOST_PORT_PORT_RANGE = 1000;
+export const FIXED_HOST_PORT_MIN_BASE_PORT = 1;
+export const FIXED_HOST_PORT_MAX_BASE_PORT = 65535 - (FIXED_HOST_PORT_PORT_RANGE - 1);
+
+export function isValidFixedHostPortBasePort(value: number | undefined): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= FIXED_HOST_PORT_MIN_BASE_PORT &&
+    value <= FIXED_HOST_PORT_MAX_BASE_PORT
+  );
+}
+
+export interface RepositoryConfiguration {
+  resources: ResourceDeclaration[];
+  endpoints: EndpointDeclaration[];
+}
+
+export interface DerivedResourcePlan {
+  resourceName: string;
+  provider: string;
+  isolationStrategy: IsolationStrategy;
+  worktreeId: string;
+  handle: string;
+}
+
+export interface DerivedEndpointMapping {
+  endpointName: string;
+  provider: string;
+  role: string;
+  worktreeId: string;
+  address: string;
+}
+
+export interface ResourceValidation {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "validate";
+}
+
+export interface ResourceReset {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "reset";
+}
+
+export interface ResourceCleanup {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "cleanup";
+}
+
+export interface ResourceProvider {
+  capabilities?: ProviderCapabilities;
+  deriveResource(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    worktree: {
+      id: string;
+      label?: string;
+      branch?: string;
+    };
+  }): DerivedResourcePlan | Refusal;
+  validateResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): ResourceValidation | Refusal;
+  resetResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): Promise<ResourceReset | Refusal>;
+  cleanupResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): Promise<ResourceCleanup | Refusal>;
+}
+
+export interface EndpointProvider {
+  deriveEndpoint(input: {
+    endpoint: {
+      name: string;
+      role: string;
+      provider: string;
+      host?: string;
+      basePort?: number;
+    };
+    worktree: {
+      id: string;
+      label?: string;
+      branch?: string;
+    };
+  }): DerivedEndpointMapping | Refusal;
+}
+
+export interface ProviderRegistry {
+  resources: Record<string, ResourceProvider>;
+  endpoints: Record<string, EndpointProvider>;
+}
+
+export type DeriveOneResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      endpointMappings: DerivedEndpointMapping[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type DeriveAndValidateOneResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      endpointMappings: DerivedEndpointMapping[];
+      resourceValidations: ResourceValidation[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type ResetOneResourceResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      resourceResets: ResourceReset[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type CleanupOneResourceResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      resourceCleanups: ResourceCleanup[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };

--- a/packages/provider-contracts/tsconfig.build.json
+++ b/packages/provider-contracts/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/packages/providers-testkit/index.ts
+++ b/packages/providers-testkit/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index.js";

--- a/packages/providers-testkit/package.json
+++ b/packages/providers-testkit/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@multiverse/providers-testkit",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@multiverse/provider-contracts": "workspace:*"
+  }
+}

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -1,0 +1,234 @@
+import type {
+  ResourceCleanup,
+  DerivedResourcePlan,
+  ProviderRegistry,
+  Refusal,
+  ResourceReset,
+  ResourceValidation,
+  RepositoryConfiguration,
+  WorktreeInstanceInput
+} from "@multiverse/provider-contracts";
+
+function unsafeScope(reason: string): Refusal {
+  return { category: "unsafe_scope", reason };
+}
+
+function deriveScopedResource(input: {
+  resource: {
+    name: string;
+    provider: string;
+    isolationStrategy: DerivedResourcePlan["isolationStrategy"];
+  };
+  worktree: WorktreeInstanceInput;
+}): DerivedResourcePlan | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    isolationStrategy: input.resource.isolationStrategy,
+    worktreeId: input.worktree.id,
+    handle: `${input.resource.name}--${input.worktree.id}`
+  };
+}
+
+function validateScopedResource(input: {
+  resource: { name: string; provider: string };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): ResourceValidation | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "validate"
+  };
+}
+
+async function resetScopedResource(input: {
+  resource: { name: string; provider: string };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): Promise<ResourceReset | Refusal> {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "reset"
+  };
+}
+
+async function cleanupScopedResource(input: {
+  resource: { name: string; provider: string };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): Promise<ResourceCleanup | Refusal> {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "cleanup"
+  };
+}
+
+export function createExplicitTestProviders(): ProviderRegistry {
+  return {
+    resources: {
+      "test-resource-provider": {
+        capabilities: { validate: true },
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({ resource, worktree });
+        },
+        validateResource({ resource, derived, worktree }) {
+          return validateScopedResource({ resource, derived, worktree });
+        }
+      },
+      "test-resource-provider-with-reset": {
+        capabilities: { reset: true },
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({ resource, worktree });
+        },
+        resetResource({ resource, derived, worktree }) {
+          return resetScopedResource({ resource, derived, worktree });
+        }
+      },
+      "test-resource-provider-with-cleanup": {
+        capabilities: { cleanup: true },
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({ resource, worktree });
+        },
+        cleanupResource({ resource, derived, worktree }) {
+          return cleanupScopedResource({ resource, derived, worktree });
+        }
+      },
+      "test-resource-provider-no-validate": {
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({ resource, worktree });
+        }
+      }
+    },
+    endpoints: {
+      "test-endpoint-provider": {
+        deriveEndpoint({ endpoint, worktree }) {
+          if (!worktree.id) {
+            return unsafeScope("Safe worktree scope cannot be determined.");
+          }
+          return {
+            endpointName: endpoint.name,
+            provider: endpoint.provider,
+            role: endpoint.role,
+            worktreeId: worktree.id,
+            address: `http://${worktree.id}.local/${endpoint.name}`
+          };
+        }
+      },
+      "test-port-endpoint-provider": {
+        deriveEndpoint({ endpoint, worktree }) {
+          if (!worktree.id) {
+            return unsafeScope("Safe worktree scope cannot be determined.");
+          }
+          return {
+            endpointName: endpoint.name,
+            provider: endpoint.provider,
+            role: endpoint.role,
+            worktreeId: worktree.id,
+            address: "http://127.0.0.1:5500"
+          };
+        }
+      }
+    }
+  };
+}
+
+export function createProvidersWithResourceDeriveRefusal(refusal: Refusal): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+  providers.resources["test-resource-provider"] = {
+    ...providers.resources["test-resource-provider"]!,
+    deriveResource() {
+      return refusal;
+    }
+  };
+  return providers;
+}
+
+export function createProvidersWithEndpointDeriveRefusal(refusal: Refusal): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+  providers.endpoints["test-endpoint-provider"] = {
+    deriveEndpoint() {
+      return refusal;
+    }
+  };
+  return providers;
+}
+
+export function createProvidersWithResourceValidateRefusal(refusal: Refusal): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+  providers.resources["test-resource-provider"] = {
+    ...providers.resources["test-resource-provider"]!,
+    validateResource() {
+      return refusal;
+    }
+  };
+  return providers;
+}
+
+export function createProvidersWithResourceResetRefusal(refusal: Refusal): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+  providers.resources["test-resource-provider-with-reset"] = {
+    ...providers.resources["test-resource-provider-with-reset"]!,
+    async resetResource() {
+      return refusal;
+    }
+  };
+  return providers;
+}
+
+export function createProvidersWithResourceCleanupRefusal(refusal: Refusal): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+  providers.resources["test-resource-provider-with-cleanup"] = {
+    ...providers.resources["test-resource-provider-with-cleanup"]!,
+    async cleanupResource() {
+      return refusal;
+    }
+  };
+  return providers;
+}
+
+export function createValidRepositoryConfiguration(
+  overrides: Partial<RepositoryConfiguration> = {}
+): RepositoryConfiguration {
+  return {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      }
+    ],
+    ...overrides
+  };
+}
+
+export function createWorktreeInstance(input: WorktreeInstanceInput): WorktreeInstanceInput {
+  return input;
+}

--- a/packages/providers-testkit/tsconfig.build.json
+++ b/packages/providers-testkit/tsconfig.build.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./",
+    "declaration": false,
+    "strict": true,
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "paths": {
+      "@multiverse/provider-contracts": ["../provider-contracts/index.ts"]
+    }
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/tests/acceptance/cleanup.acceptance.test.ts
+++ b/tests/acceptance/cleanup.acceptance.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { cleanupOneResource } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceCleanupRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("cleanup: scoped resource cleanup", () => {
+  it("cleans up resources that declare scopedCleanup: true", async () => {
+    const outcome = await cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-cleanup", label: "cleanup" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourcePlans).toHaveLength(1);
+    expect(outcome.resourceCleanups).toHaveLength(1);
+    expect(outcome.resourceCleanups[0]).toMatchObject({
+      resourceName: "primary-db",
+      provider: "test-resource-provider-with-cleanup",
+      worktreeId: "wt-cleanup",
+      capability: "cleanup"
+    });
+  });
+
+  it("refuses when no resources declare scopedCleanup", async () => {
+    const outcome = await cleanupOneResource({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-no-cleanup" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "invalid_configuration" }
+    });
+  });
+
+  it("refuses when provider does not declare cleanup capability", async () => {
+    const outcome = await cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-unsupported-cleanup" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "unsupported_capability" }
+    });
+  });
+
+  it("surfaces a provider cleanup refusal", async () => {
+    const outcome = await cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-cleanup-refusal" }),
+      providers: createProvidersWithResourceCleanupRefusal({
+        category: "provider_failure",
+        reason: "cleanup failed"
+      })
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "provider_failure" } });
+  });
+});

--- a/tests/acceptance/derive.acceptance.test.ts
+++ b/tests/acceptance/derive.acceptance.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { deriveOne } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithEndpointDeriveRefusal,
+  createProvidersWithResourceDeriveRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("derive: core isolation guarantees", () => {
+  it("resolves successfully for a valid declared worktree instance", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-feature-a", label: "feature-a", branch: "feature/shared" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourcePlans).toHaveLength(1);
+    expect(outcome.endpointMappings).toHaveLength(1);
+    expect(outcome.resourcePlans[0]).toMatchObject({
+      resourceName: "primary-db",
+      provider: "test-resource-provider",
+      isolationStrategy: "name-scoped",
+      worktreeId: "wt-feature-a"
+    });
+    expect(typeof outcome.resourcePlans[0]!.handle).toBe("string");
+    expect(outcome.endpointMappings[0]).toMatchObject({
+      endpointName: "app-base-url",
+      provider: "test-endpoint-provider",
+      role: "application-base-url",
+      worktreeId: "wt-feature-a"
+    });
+    expect(typeof outcome.endpointMappings[0]!.address).toBe("string");
+  });
+
+  it("derives deterministically for the same worktree instance", () => {
+    const repository = createValidRepositoryConfiguration();
+    const worktree = createWorktreeInstance({ id: "wt-repeatable", label: "repeatable", branch: "feature/repeatable" });
+    const providers = createExplicitTestProviders();
+
+    const first = deriveOne({ repository, worktree, providers });
+    const second = deriveOne({ repository, worktree, providers });
+
+    expect(first).toEqual(second);
+  });
+
+  it("resolves successfully for the reserved main worktree identity", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "main", label: "main" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourcePlans[0]).toMatchObject({ worktreeId: "main" });
+    expect(outcome.endpointMappings[0]).toMatchObject({ worktreeId: "main" });
+  });
+
+  it("derives different isolated outputs for different worktree instances sharing a branch", () => {
+    const repository = createValidRepositoryConfiguration();
+    const providers = createExplicitTestProviders();
+
+    const first = deriveOne({
+      repository,
+      worktree: createWorktreeInstance({ id: "wt-first", label: "first", branch: "feature/shared" }),
+      providers
+    });
+    const second = deriveOne({
+      repository,
+      worktree: createWorktreeInstance({ id: "wt-second", label: "second", branch: "feature/shared" }),
+      providers
+    });
+
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+
+    expect(first.resourcePlans[0]!.handle).not.toBe(second.resourcePlans[0]!.handle);
+    expect(first.endpointMappings[0]!.address).not.toBe(second.endpointMappings[0]!.address);
+  });
+});
+
+describe("derive: refusal behavior", () => {
+  it("refuses when worktree ID is absent", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: { label: "ambiguous-scope", branch: "feature/shared" },
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "unsafe_scope" }
+    });
+  });
+
+  it("refuses whitespace-only worktree ID before invoking any provider", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider"]!,
+      "deriveResource"
+    );
+    const deriveEndpoint = vi.spyOn(
+      providers.endpoints["test-endpoint-provider"]!,
+      "deriveEndpoint"
+    );
+
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "   ", label: "invalid" }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "unsafe_scope" } });
+    expect(deriveResource).not.toHaveBeenCalled();
+    expect(deriveEndpoint).not.toHaveBeenCalled();
+  });
+
+  it("refuses when provider assignment is missing from a resource declaration", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration({
+        resources: [{ name: "primary-db", isolationStrategy: "name-scoped", scopedReset: false, scopedCleanup: false }]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-missing-provider" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "invalid_configuration" } });
+  });
+
+  it("refuses when a required endpoint field is missing", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration({
+        endpoints: [{ name: "app-base-url", provider: "test-endpoint-provider" }]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-invalid-endpoint" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "invalid_configuration" } });
+  });
+
+  it("surfaces a provider resource derive refusal", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-provider-refusal" }),
+      providers: createProvidersWithResourceDeriveRefusal({
+        category: "provider_failure",
+        reason: "backing system unavailable"
+      })
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "provider_failure" } });
+  });
+
+  it("surfaces a provider endpoint derive refusal", () => {
+    const outcome = deriveOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-endpoint-refusal" }),
+      providers: createProvidersWithEndpointDeriveRefusal({
+        category: "provider_failure",
+        reason: "endpoint derivation failed"
+      })
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "provider_failure" } });
+  });
+});

--- a/tests/acceptance/reset.acceptance.test.ts
+++ b/tests/acceptance/reset.acceptance.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { resetOneResource } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceResetRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("reset: scoped resource reset", () => {
+  it("resets resources that declare scopedReset: true", async () => {
+    const outcome = await resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-reset", label: "reset" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourcePlans).toHaveLength(1);
+    expect(outcome.resourceResets).toHaveLength(1);
+    expect(outcome.resourceResets[0]).toMatchObject({
+      resourceName: "primary-db",
+      provider: "test-resource-provider-with-reset",
+      worktreeId: "wt-reset",
+      capability: "reset"
+    });
+  });
+
+  it("refuses when no resources declare scopedReset", async () => {
+    const outcome = await resetOneResource({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-no-reset" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "invalid_configuration" }
+    });
+  });
+
+  it("refuses when provider does not declare reset capability", async () => {
+    const outcome = await resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-unsupported-reset" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "unsupported_capability" }
+    });
+  });
+
+  it("surfaces a provider reset refusal", async () => {
+    const outcome = await resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-reset-refusal" }),
+      providers: createProvidersWithResourceResetRefusal({
+        category: "provider_failure",
+        reason: "reset failed"
+      })
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "provider_failure" } });
+  });
+});

--- a/tests/acceptance/validate.acceptance.test.ts
+++ b/tests/acceptance/validate.acceptance.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveAndValidateOne } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceValidateRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("validate: derive and validate resources", () => {
+  it("derives and validates resources that declare scopedValidate: true", () => {
+    const outcome = deriveAndValidateOne({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-validate", label: "validate" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourcePlans).toHaveLength(1);
+    expect(outcome.resourceValidations).toHaveLength(1);
+    expect(outcome.resourceValidations[0]).toMatchObject({
+      resourceName: "primary-db",
+      provider: "test-resource-provider",
+      worktreeId: "wt-validate",
+      capability: "validate"
+    });
+  });
+
+  it("produces an empty resourceValidations array when no resource declares scopedValidate", () => {
+    const outcome = deriveAndValidateOne({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({ id: "wt-no-validate" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+
+    expect(outcome.resourceValidations).toHaveLength(0);
+  });
+
+  it("refuses when provider does not declare validate capability", () => {
+    const outcome = deriveAndValidateOne({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-no-validate",
+            isolationStrategy: "name-scoped",
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-unsupported-validate" }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: { category: "unsupported_capability" }
+    });
+  });
+
+  it("surfaces a provider validate refusal", () => {
+    const outcome = deriveAndValidateOne({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({ id: "wt-validate-refusal" }),
+      providers: createProvidersWithResourceValidateRefusal({
+        category: "provider_failure",
+        reason: "validation check failed"
+      })
+    });
+
+    expect(outcome).toMatchObject({ ok: false, refusal: { category: "provider_failure" } });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,16 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["tools/**/*.ts", "vitest.config.ts"]
+  "compilerOptions": {
+    "paths": {
+      "@multiverse/provider-contracts": ["./packages/provider-contracts/index.ts"],
+      "@multiverse/core": ["./packages/core/index.ts"],
+      "@multiverse/providers-testkit": ["./packages/providers-testkit/index.ts"]
+    }
+  },
+  "include": [
+    "tools/**/*.ts",
+    "packages/**/*.ts",
+    "tests/**/*.ts",
+    "vitest.config.ts"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,21 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@multiverse/provider-contracts": new URL(
+        "./packages/provider-contracts/index.ts",
+        import.meta.url
+      ).pathname,
+      "@multiverse/core": new URL("./packages/core/index.ts", import.meta.url).pathname,
+      "@multiverse/providers-testkit": new URL(
+        "./packages/providers-testkit/index.ts",
+        import.meta.url
+      ).pathname
+    }
+  },
   test: {
     environment: "node",
-    include: ["**/*.test.ts"]
+    include: ["**/*.test.ts", "**/*.acceptance.test.ts"]
   }
 });


### PR DESCRIPTION
## Summary

- `packages/provider-contracts` — full TypeScript type surface: isolation strategies, refusal categories, resource/endpoint provider interfaces, provider registry, all result union types
- `packages/core` — orchestration: `deriveOne`, `deriveAndValidateOne`, `resetOneResource`, `cleanupOneResource` with worktree identity validation, repository configuration validation, declaration validation, and refusal factory helpers
- `packages/providers-testkit` — deterministic test provider registry, configuration builders, and refusal injection helpers for acceptance tests
- 4 acceptance test files, 23 tests across derive, validate, reset, and cleanup — covering isolation guarantees, determinism, refusal by category, and provider boundary behavior
- Workspace path aliases wired in `tsconfig.json` and `vitest.config.ts`

## Test plan

- [x] `pnpm test` — 23 tests pass (5 test files)
- [x] `pnpm typecheck` — clean with `exactOptionalPropertyTypes: true`
- [x] `pnpm agent:verify` — 13 artifacts, 3 source records
- [x] `pnpm docs:verify` — build + smoke gate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)